### PR TITLE
Move credentials out of service file

### DIFF
--- a/conf/env
+++ b/conf/env
@@ -1,0 +1,5 @@
+__SYNC_USER_1__
+__SYNC_USER_2__
+__SYNC_USER_3__
+__SYNC_USER_4__
+__SYNC_USER_5__

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -10,11 +10,6 @@ WorkingDirectory=__INSTALL_DIR__
 Environment="SYNC_BASE=__DATA_DIR__"
 Environment="SYNC_HOST=127.0.0.1"
 Environment="SYNC_PORT=__PORT__"
-__SYNC_USER_1__
-__SYNC_USER_2__
-__SYNC_USER_3__
-__SYNC_USER_4__
-__SYNC_USER_5__
 __MAX_SYNC_PAYLOAD_MEGS__
 ExecStart=__INSTALL_DIR__/anki-syncserver
 StandardOutput=append:/var/log/__APP__/__APP__.log

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -11,6 +11,7 @@ Environment="SYNC_BASE=__DATA_DIR__"
 Environment="SYNC_HOST=127.0.0.1"
 Environment="SYNC_PORT=__PORT__"
 __MAX_SYNC_PAYLOAD_MEGS__
+EnvironmentFile=__INSTALL_DIR__/.env.systemd
 ExecStart=__INSTALL_DIR__/anki-syncserver
 StandardOutput=append:/var/log/__APP__/__APP__.log
 StandardError=inherit

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -49,6 +49,10 @@ configure_systemd_service() {
     sync_user_5=$(gen_sync_user "5" "$sync_user_5")
     max_sync_payload_megs=$(gen_max_sync_payload "$max_sync_payload_megs")
 
+    ynh_add_config --template="env" --destination="$install_dir/.env.systemd"
+    chown $app:$app "$install_dir/.env.systemd"
+    chmod 600 "$install_dir/.env.systemd"
+
     ynh_add_systemd_config
 
     systemctl daemon-reload


### PR DESCRIPTION
`xxx.service` files are readable by all the users, plaintext credentials do not belong there