### PR TITLE
Fix .env format

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -7,9 +7,9 @@ gen_sync_user() {
     value="$2"
 
     if [ -n "$value" ]; then
-        echo "Environment=\"SYNC_USER${n}=${value}\"" 
+        echo "SYNC_USER${n}=${value}" 
     else
-        echo "#Environment=\"SYNC_USER${n}=\""
+        echo "#SYNC_USER${n}="
     fi
 }
 

--- a/tests.toml
+++ b/tests.toml
@@ -7,3 +7,5 @@ test_format = 1.0
     # ------------
     # Tests to run
     # ------------
+    [default.curl_tests]
+    health.path = "/health"


### PR DESCRIPTION
utils in `_common.sh` were emitting lines formatted for `systemd`, make these compatible with plain `.env` files.